### PR TITLE
Added min and max resistance changing and added some extra precision

### DIFF
--- a/DS3904/DS3904.cpp
+++ b/DS3904/DS3904.cpp
@@ -19,9 +19,18 @@ DS3904::DS3904(int deviceAddress, int model)
   init();
 }
 
+DS3904::DS3904(int deviceAddress, int model, int minValue, int maxValue)
+{
+  _deviceAddress = deviceAddress;
+  _model = model;
+  MIN_VALUES[model] = minValue;
+  MAX_VALUES[model] = maxValue;
+  init();
+}
+
 void DS3904::init() 
 {
-  _ohmPerStep = (MAX_VALUES[_model] - MIN_VALUES[_model]) / STEPS;
+  _ohmPerStep = (MAX_VALUES[_model] - MIN_VALUES[_model]) / float(STEPS);
 }
 
 void DS3904::setValue(byte resistorAddress, byte value)
@@ -46,23 +55,23 @@ byte DS3904::getValue(byte resistorAddress)
   return result;
 }
 
-void DS3904::setOhmValue(byte resistorAddress, long ohms)
+void DS3904::setOhmValue(byte resistorAddress, double ohms)
 {
   byte value = fromOhms(ohms);  
   setValue(resistorAddress, value);
 }
 
-byte DS3904::fromOhms(long ohms) 
+byte DS3904::fromOhms(double ohms) 
 {
   return ohms / _ohmPerStep;
 }
 
-long DS3904::toOhms(byte value) {
+double DS3904::toOhms(byte value) {
   if ((value & HIGH_Z) == HIGH_Z) return HIGH_Z_OHM;
-  return value * _ohmPerStep;
+  return (value * _ohmPerStep) + MIN_VALUES[_model];
 }
 
-long DS3904::getOhmValue(byte resistorAddress)
+double DS3904::getOhmValue(byte resistorAddress)
 {
   byte value = getValue(resistorAddress);
   return toOhms(value);

--- a/DS3904/DS3904.cpp
+++ b/DS3904/DS3904.cpp
@@ -19,9 +19,18 @@ DS3904::DS3904(int deviceAddress, int model)
   init();
 }
 
+DS3904::DS3904(int deviceAddress, int model, int minValue, int maxValue)
+{
+  _deviceAddress = deviceAddress;
+  _model = model;
+  MIN_VALUES[model] = minValue;
+  MAX_VALUES[model] = maxValue;
+  init();
+}
+
 void DS3904::init() 
 {
-  _ohmPerStep = (MAX_VALUES[_model] - MIN_VALUES[_model]) / STEPS;
+  _ohmPerStep = (MAX_VALUES[_model] - MIN_VALUES[_model]) / float(STEPS);
 }
 
 void DS3904::setValue(byte resistorAddress, byte value)
@@ -46,23 +55,23 @@ byte DS3904::getValue(byte resistorAddress)
   return result;
 }
 
-void DS3904::setOhmValue(byte resistorAddress, long ohms)
+void DS3904::setOhmValue(byte resistorAddress, double ohms)
 {
   byte value = fromOhms(ohms);  
   setValue(resistorAddress, value);
 }
 
-byte DS3904::fromOhms(long ohms) 
+byte DS3904::fromOhms(double ohms) 
 {
   return ohms / _ohmPerStep;
 }
 
-long DS3904::toOhms(byte value) {
+double DS3904::toOhms(byte value) {
   if ((value & HIGH_Z) == HIGH_Z) return HIGH_Z_OHM;
   return value * _ohmPerStep;
 }
 
-long DS3904::getOhmValue(byte resistorAddress)
+double DS3904::getOhmValue(byte resistorAddress)
 {
   byte value = getValue(resistorAddress);
   return toOhms(value);

--- a/DS3904/DS3904.h
+++ b/DS3904/DS3904.h
@@ -28,17 +28,18 @@ class DS3904
   public:
     DS3904(int deviceAddress);
     DS3904(int deviceAddress, int model);
+    DS3904(int deviceAddress, int model, int minValue, int maxValue);
     void setValue(byte resistorAddress, byte value);
     byte getValue(byte resistorAddress);
-    void setOhmValue(byte resistorAddress, long ohms);
-    long getOhmValue(byte resistorAddress);
-    long toOhms(byte value);
-    byte fromOhms(long ohms);
+    void setOhmValue(byte resistorAddress, double ohms);
+    double getOhmValue(byte resistorAddress);
+    double toOhms(byte value);
+    byte fromOhms(double ohms);
   private:
     void init();
     int _deviceAddress;
     int _model;  
-    int _ohmPerStep;  
+    float _ohmPerStep;  
 };
 
 #endif

--- a/DS3904/DS3904.h
+++ b/DS3904/DS3904.h
@@ -20,7 +20,7 @@ http://datasheets.maximintegrated.com/en/ds/DS3904-DS3905.pdf*/
 #define DS3905_020 2
 #define BASE_ADDRESS 0x50
 #define WRITE_DELAY 20
-#define STEPS 0x80
+#define STEPS 0x7F
 #define HIGH_Z_OHM 5500000
 
 class DS3904
@@ -28,17 +28,19 @@ class DS3904
   public:
     DS3904(int deviceAddress);
     DS3904(int deviceAddress, int model);
+    DS3904(int deviceAddress, int model, int minValue, int maxValue);
     void setValue(byte resistorAddress, byte value);
     byte getValue(byte resistorAddress);
-    void setOhmValue(byte resistorAddress, long ohms);
-    long getOhmValue(byte resistorAddress);
-    long toOhms(byte value);
-    byte fromOhms(long ohms);
+    void setOhmValue(byte resistorAddress, double ohms);
+    double getOhmValue(byte resistorAddress);
+    double toOhms(byte value);
+    byte fromOhms(double ohms);
+    float getStep()
   private:
     void init();
     int _deviceAddress;
     int _model;  
-    int _ohmPerStep;  
+    float _ohmPerStep;  
 };
 
 #endif


### PR DESCRIPTION
I understand that this library has not seen a commit in several years. Regardless, I feel the need to allow users of this library to configure the resistances within their digital potentiometers to their own environment. The 200 Ω minimum set within the original is the lowest amount of resistance specified in the data sheet. My measures have consistently been around 400 Ω at room temperature. The same is true for the maximum resistance. Though a small difference like this may be fine for some projects, it is not fine for all of them.